### PR TITLE
add shift.me to api request

### DIFF
--- a/lib/shiftplanning/request.rb
+++ b/lib/shiftplanning/request.rb
@@ -129,6 +129,7 @@ class ShiftPlanning
       @staff = _staff.new(
         SPModule.new('staff.login', 'GET', {}, %w(GET), {:GET => %w(username password)}),
         SPModule.new('staff.logout', 'GET', {}, %w(GET), {:GET => %w(token)}),
+        SPModule.new('staff.me', 'GET', {}, %w(GET), {:GET => %w(token)}),
         SPModule.new('staff.employees', 'GET', {}, %w(GET CREATE), {:GET => %w(token), :CREATE => %w(token)}),
         SPModule.new('staff.employee', 'GET', {}, %w(GET CREATE UPDATE DELETE), {
           :GET => %w(token), :CREATE => %w(token), :UPDATE => %w(token id), :DELETE => %w(token id)


### PR DESCRIPTION
This PR is making the shift.me API endpoint publicly available. https://www.humanity.shiftplanning.com/api/staff.me/

This allows us to view the timezone set for the authenticated viewer/user.
